### PR TITLE
Add GitHub Actions workflow for Docker image publishing

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yml
+++ b/.github/workflows/build-and-publish-container-image.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ghcr.io/${{ github.repository_owner }}/money-printer-v2:latest

--- a/.github/workflows/build-and-publish-container-image.yml
+++ b/.github/workflows/build-and-publish-container-image.yml
@@ -1,0 +1,33 @@
+name: Publish Docker image to GHCR
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub workflow responsible for building the Docker image and pushing it to the GitHub container registry.

## Details
- Adds a new workflow triggered on pushes and pull requests to the master branch.
- The workflow logs into GHCR using the repository owner and the default GITHUB_TOKEN.
- Builds the Docker image.
- Pushes the image to: `ghcr.io/FujiwaraChoki/MoneyPrinterV2:latest`

## Purpose
This workflow automates the Docker image build and deployment process, ensuring the container is always up to date when changes are merged into main.

## Notes
Having an official published image will make distribution and updates much easier.